### PR TITLE
 get, add, remove issuedemo

### DIFF
--- a/Test/public/IssueDemo.test/issuedemo.test.ps1
+++ b/Test/public/IssueDemo.test/issuedemo.test.ps1
@@ -1,4 +1,4 @@
-function Test_addIssuedemo {
+function Test_Issuedemo_Cicle {
 
     Assert-SkipTest
 
@@ -9,7 +9,7 @@ function Test_addIssuedemo {
     $result = Get-IssueDemo -RepoWithOwner $repoDestination
     Assert-Count -Expected 0 -Presented $result
 
-    
+
     $issues = Get-IssueDemo -RepoWithOwner $repoSource -Verbose
     Assert-Count -Expected 8 -Presented $issues
 

--- a/Test/public/IssueDemo.test/issuedemo.test.ps1
+++ b/Test/public/IssueDemo.test/issuedemo.test.ps1
@@ -1,0 +1,20 @@
+function Test_addIssuedemo {
+
+    Assert-SkipTest
+
+    $repoDestination = "octodemo/animated-train"
+    $repoSource = "rulasg/dotnet-api-demo"
+
+    Remove-IssueDemo -RepoWithOwner $repoDestination -Verbose
+    $result = Get-IssueDemo -RepoWithOwner $repoDestination
+    Assert-Count -Expected 0 -Presented $result
+
+    
+    $issues = Get-IssueDemo -RepoWithOwner $repoSource -Verbose
+    Assert-Count -Expected 8 -Presented $issues
+
+    $result = $issues | Add-IssueDemo -RepoWithOwner $repoDestination -Verbose
+
+    Assert-count -Expected 8 -Presented $result
+
+}

--- a/public/IssueDemo/issuesdemo.ps1
+++ b/public/IssueDemo/issuesdemo.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+Retrieves issues from a specified GitHub repository.
+
+.DESCRIPTION
+The Get-IssueDemo function uses the GitHub CLI to list issues from a specified repository.
+It converts the JSON response to PowerShell objects and formats the output.
+
+.PARAMETER RepoWithOwner
+The repository name with the owner in the format 'owner/repo'.
+
+.EXAMPLE
+Get-IssueDemo -RepoWithOwner 'microsoft/vscode'
+This example retrieves issues from the 'microsoft/vscode' repository.
+
+.NOTES
+Requires GitHub CLI (gh) to be installed and authenticated.
+#>
 function Get-IssueDemo {
     [CmdletBinding()]
     param(
@@ -30,8 +48,35 @@ function Get-IssueDemo {
 
 } Export-ModuleMember -Function Get-IssueDemo
 
+<#
+.SYNOPSIS
+Adds a new issue to a specified GitHub repository.
+
+.DESCRIPTION
+The `Add-IssueDemo` function creates a new issue in a specified GitHub repository using the GitHub CLI (`gh`).
+
+.PARAMETER Title
+The title of the issue.
+
+.PARAMETER Body
+The body content of the issue.
+
+.PARAMETER Labels
+Comma-separated labels to assign to the issue.
+
+.PARAMETER RepoWithOwner
+The repository to which the issue will be added, in the format `owner/repo`.
+
+.EXAMPLE
+PS> Add-IssueDemo -Title "Bug Report" -Body "There is a bug in the application." -Labels "bug,urgent" -RepoWithOwner "user/repo"
+
+This command creates a new issue in the specified repository with the given title, body, and labels.
+
+.NOTES
+Requires the GitHub CLI (`gh`) to be installed and authenticated.
+#>
 function Add-IssueDemo {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(ValueFromPipelineByPropertyName)][string]$Title,
         [Parameter(ValueFromPipelineByPropertyName)][string]$Body,
@@ -46,16 +91,37 @@ function Add-IssueDemo {
 
     process {
 
-        $result = gh issue create -t $Title -b $Body -l $Labels -R $RepoWithOwner
-
-        $result | Write-Verbose
-
-        return $result
+        if ($PSCmdlet.ShouldProcess("Add", "gh issue create -t $Title -b <MultilineContet> -l $Labels -R $RepoWithOwner")) {
+            $result = gh issue create -t $Title -b $Body -l $Labels -R $RepoWithOwner
+            
+            $result | Write-Verbose
+            
+            return $result
+        }
+        
     }
 } Export-ModuleMember -Function Add-IssueDemo
 
+<#
+.SYNOPSIS
+Removes all issues from a specified GitHub repository.
+
+.DESCRIPTION
+The `Remove-IssueDemo` function deletes all issues from a specified GitHub repository using the GitHub CLI (`gh`).
+
+.PARAMETER RepoWithOwner
+The repository from which the issues will be removed, in the format `owner/repo`.
+
+.EXAMPLE
+PS> Remove-IssueDemo -RepoWithOwner "user/repo"
+
+This command removes all issues from the specified repository.
+
+.NOTES
+Requires the GitHub CLI (`gh`) to be installed and authenticated.
+#>
 function Remove-IssueDemo {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Position=0)][string]$RepoWithOwner
     )
@@ -66,14 +132,16 @@ function Remove-IssueDemo {
 
     foreach ($i in $issues) {
 
-        "Removing issue {0}" -f $i.Url | Write-Verbose
+        if ($PSCmdlet.ShouldProcess("Remove", "gh issue delete $issueNumber -R $RepoWithOwner --yes")) {
+            "Removing issue {0}" -f $i.Url | Write-Verbose
 
-        $issueNumber = $i.number
-        $result = gh issue delete $issueNumber -R $RepoWithOwner --yes
+            $issueNumber = $i.number
+            $result = gh issue delete $issueNumber -R $RepoWithOwner --yes
 
-        $result | write-verbose
+            $result | write-verbose
 
-        Write-Output $result
+            Write-Output $result
+        }
     }
 } Export-ModuleMember -Function Remove-IssueDemo
 

--- a/public/IssueDemo/issuesdemo.ps1
+++ b/public/IssueDemo/issuesdemo.ps1
@@ -1,0 +1,97 @@
+function Get-IssueDemo {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0)][string]$RepoWithOwner
+    )
+
+    "Getting issues from $RepoWithOwner" | Write-Verbose
+
+    $issuesJson = gh issue list -R $RepoWithOwner --json number,title,body,labels,number,url
+
+    $issues = $issuesJson | ConvertFrom-Json -Depth 10
+
+    "Found {0} issues in $RepoWithOwner" -f $issues.Count | Write-Verbose
+
+    foreach ($i in $issues) {
+        $labels = Get-Labels -Labels $i.labels
+    
+        $ret = $ret | ForEach-Object {
+            [PSCustomObject]@{
+                Number = if ($null -eq $i.number) { [string]::Empty } else { $i.number }
+                Title  = if ($null -eq $i.title) { [string]::Empty } else { $i.title }
+                Body   = if ($null -eq $i.body) { [string]::Empty } else { $i.body }
+                Labels = if ($null -eq $labels) { [string]::Empty } else { $labels }
+                Url    = if ($null -eq $i.url) { [string]::Empty } else { $i.url }
+            }
+        }
+
+        Write-Output $ret
+    }
+
+} Export-ModuleMember -Function Get-IssueDemo
+
+function Add-IssueDemo {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipelineByPropertyName)][string]$Title,
+        [Parameter(ValueFromPipelineByPropertyName)][string]$Body,
+        [Parameter(ValueFromPipelineByPropertyName)][string]$Labels,
+
+        [Parameter()][string]$RepoWithOwner
+    )
+
+    begin{
+        "Adding issue to $RepoWithOwner" | Write-Verbose
+    }
+
+    process {
+
+        $result = gh issue create -t $Title -b $Body -l $Labels -R $RepoWithOwner
+
+        $result | Write-Verbose
+
+        return $result
+    }
+} Export-ModuleMember -Function Add-IssueDemo
+
+function Remove-IssueDemo {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0)][string]$RepoWithOwner
+    )
+
+    "Removing issues from $RepoWithOwner" | Write-Verbose
+
+    $issues = Get-IssueDemo -RepoWithOwner $RepoWithOwner
+
+    foreach ($i in $issues) {
+
+        "Removing issue {0}" -f $i.Url | Write-Verbose
+
+        $issueNumber = $i.number
+        $result = gh issue delete $issueNumber -R $RepoWithOwner --yes
+
+        $result | write-verbose
+
+        Write-Output $result
+    }
+} Export-ModuleMember -Function Remove-IssueDemo
+
+function Get-Labels {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0)][object] $Labels
+    )
+
+    process {
+
+        $names = $Labels.Name
+
+        $names = $names | Where-Object { $_ -notmatch '\s' }
+
+        $ret = $names -join ","
+
+        return $ret
+
+    }
+}


### PR DESCRIPTION
New PowerShell functions for issue management:

* [`public/IssueDemo/issuesdemo.ps1`](diffhunk://#diff-114f76a60d873e59e4c1a814a07ac67d3003691564a2969b049278e448e3e917R1-R97): Added functions `Get-IssueDemo`, `Add-IssueDemo`, `Remove-IssueDemo`, and `Get-Labels` to manage GitHub issues. These functions allow fetching issues, adding new issues, removing issues, and processing issue labels, respectively.

Testing enhancements:

* [`Test/public/IssueDemo.test/issuedemo.test.ps1`](diffhunk://#diff-c3408914705c7bb6973e87d7462fb659cf9197b245859b215c4f5b2c5999f2a9R1-R20): Added the `Test_addIssuedemo` function to test the issue management functions. This function verifies the addition and removal of issues between two repositories.