### PR TITLE
Add PowerShell module and testing Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+
+## Powershell Modules Code Instructions
+
+### PowerShell Functions Instructions
+Every powershell function will contain the `CmdletBinding` attribute and the `parm`iven if there are no parameters. 
+If the function is on the public folder of the module, we will add the Èxport-ModuleFunction` statement in the same line as the closing `}` of the function
+
+Sample of function will be:
+
+```powershell
+
+function Get-UserName{
+    [CmdletBinding()]
+    param()
+
+    #Logic of the function
+} Export-ModuleFunction -FunctionName 'Get-UserName'
+```
+
+### PowerShell Test Instructions
+Every public function on the Test module will have the following format
+- Name will start with `Test_` will follow the name of the function that we are testing with no '-'. It will follow the intention of the test splited with a '_'
+- Every time we create a new function with no body we will add the `Assert-NotImplemented` statement at the end
+- We will add the 3 sections as with comments `Arrange`, `Act` and `Assert` to make the test more readable.
+- Sample of a test function to test `Get-UserName` function  will be `Test_GetUserName_UserNotFound`
+
+Full sample will be as follows
+
+```powershell
+function Test_GetUserName_UserNotFound{
+
+    # Arrange
+
+    # Act
+
+    # Assert
+
+    Assert-NotImplemented
+} 
+```


### PR DESCRIPTION
Guidelines for PowerShell modules and tests:

* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R40): Added instructions for PowerShell functions, including the use of the `CmdletBinding` attribute, `param` keyword, and `Export-ModuleFunction` statement.
* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R40): Added guidelines for writing PowerShell test functions, specifying naming conventions, the use of `Assert-NotImplemented`, and the inclusion of `Arrange`, `Act`, and `Assert` sections.This pull request adds new instructions for writing PowerShell modules and tests to the `.github/copilot-instructions.md` file. The most important changes include guidelines for structuring PowerShell functions and tests to ensure consistency and readability.