### PR TITLE
Codespace get and new

### DIFF
--- a/public/codespace/codespaces.ps1
+++ b/public/codespace/codespaces.ps1
@@ -1,0 +1,66 @@
+<#
+.SYNOPSIS
+Creates a codespace in the main branch of a specified GitHub repository.
+
+.DESCRIPTION
+The `New-Codespace` function creates a new codespace in the main branch of a specified GitHub repository using the GitHub CLI (`gh`).
+
+.PARAMETER RepoWithOwner
+The repository name with the owner in the format 'owner/repo'.
+
+.EXAMPLE
+New-Codespace -RepoWithOwner 'octodemo/mushy-chainsaw'
+This example creates a codespace in the main branch of the 'octodemo/mushy-chainsaw' repository.
+
+.NOTES
+Requires GitHub CLI (gh) to be installed and authenticated.
+#>
+function New-DemoCodespace {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0)][string]$RepoWithOwner,
+        [Parameter(Position=1)][string]$DisplayName
+    )
+
+    "Creating codespace in the main branch of $RepoWithOwner" | Write-Verbose
+
+    $ghCommand = "gh cs create -b main -m 'standardLinux32gb' -R $RepoWithOwner"
+    if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('DisplayName')) {
+        $ghCommand += " --display-name '$DisplayName'"
+    }
+
+    $result = Invoke-Expression $ghCommand
+
+    $result | Write-Verbose
+
+    return $result
+} Export-ModuleMember -Function 'New-DemoCodespace'
+
+
+function Get-DemoCodespaces {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0)][string]$owner = 'octodemo'
+    )
+
+    "Getting codespaces in the $RepoWithOwner repository" | Write-Verbose
+
+    $json = gh cs list --json name,displayName,owner,repository
+
+    $json | Write-Verbose
+
+    $codespaces = $json | ConvertFrom-Json -Depth 10
+
+    $result = $codespaces | Where-Object { $_.repository -Like "$owner/*" } | ForEach-Object {
+        [PSCustomObject]@{
+            Name = $_.name
+            DisplayName = $_.displayName
+            Owner = $_.owner
+            Repository = $_.repository
+        }
+    }
+
+    $result | Write-Verbose
+
+    return $result
+} Export-ModuleMember -Function 'Get-DemoCodespaces'


### PR DESCRIPTION
New functionalities added:

* [`public/codespace/codespaces.ps1`](diffhunk://#diff-93d11de64c3426124861acbfbe182ff1bfacd66cb5ffa95c1910ae1619ebfb97R1-R66): Added the `New-DemoCodespace` function to create a new codespace in the main branch of a specified GitHub repository using the GitHub CLI (`gh`).
* [`public/codespace/codespaces.ps1`](diffhunk://#diff-93d11de64c3426124861acbfbe182ff1bfacd66cb5ffa95c1910ae1619ebfb97R1-R66): Added the `Get-DemoCodespaces` function to list existing codespaces for a specified owner using the GitHub CLI (`gh`).